### PR TITLE
Update selectors

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ chrome.storage.local.get(['pattern', 'case_insensitive', 'color', 'opacity'], fu
   opacity = items.opacity || 0.7;
 
   var unhighlighter = function(element, re, color, opacity) {
-    var items = element.querySelectorAll('.list-group-item-name, .issue-title-link');
+    var items = element.querySelectorAll('.Box-row-link');
     Array.prototype.filter.call(items, function(item) {
       if (item.innerText.match(re)) {
         element.style.backgroundColor = color;
@@ -30,7 +30,7 @@ chrome.storage.local.get(['pattern', 'case_insensitive', 'color', 'opacity'], fu
   };
 
   var walk = function(re, color, opacity) {
-    var elements = document.querySelectorAll('.pulls-list-group li.list-group-item, ul.table-list-issues li.table-list-item');
+    var elements = document.querySelectorAll('.js-issue-row');
     Array.prototype.forEach.call(elements, function(element) {
       unhighlighter(element, re, color, opacity);
     });

--- a/app.js
+++ b/app.js
@@ -21,17 +21,17 @@ chrome.storage.local.get(['pattern', 'case_insensitive', 'color', 'opacity'], fu
 
   var unhighlighter = function(element, re, color, opacity) {
     var items = element.querySelectorAll('.Box-row-link');
-    Array.prototype.filter.call(items, function(item) {
+    Array.from(items).filter(function(item) {
       if (item.innerText.match(re)) {
         element.style.backgroundColor = color;
         element.style.opacity = opacity;
       }
-    })
+    });
   };
 
   var walk = function(re, color, opacity) {
     var elements = document.querySelectorAll('.js-issue-row');
-    Array.prototype.forEach.call(elements, function(element) {
+    Array.from(elements).forEach(function(element) {
       unhighlighter(element, re, color, opacity);
     });
   }


### PR DESCRIPTION
It seems to be changed.

Also, fixed to use `Array.from`. https://github.com/kyanny/chrome-ext-wip-pull-request-unhighlighter-for-github/commit/4737133a11a4137d8572b919262fe7949e82010d
It's supported since Chrome Ver. 45.
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from

But I've not tested yet since i'm not sure how to do it.